### PR TITLE
Added Tor Metrics to support.tpo/glossary

### DIFF
--- a/content/glossary/metrics/contents.lr
+++ b/content/glossary/metrics/contents.lr
@@ -1,0 +1,11 @@
+_model: word
+---
+term: Tor Metrics
+---
+definition:
+
+[Tor Metrics](https://metrics.torproject.org/) ([.onion](http://rougmnvswfsmd4dq.onion/)) archives historical data about the Tor ecosystem, collects data from the public Tor network and related services, and assists in developing novel approaches to safe, privacy preserving data collection.
+---
+translation: 
+---
+spelling: 


### PR DESCRIPTION
I think Tor Metrics is missing on support.tpo/glossary so i added it.
Definition from https://metrics.torproject.org/about.html